### PR TITLE
Update the regex to account for numbers

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,7 +73,7 @@ def logZoomEvent(req):
 			print("PD CONF URL : ", bridge["metadata"].get("conference_url"))
 			
 			if bridge["metadata"].get("conference_url"):
-				conf = re.findall("[\d]+", bridge["metadata"]["conference_url"].replace('-', ''))[0]
+				conf = re.findall("[\d]+\?", bridge["metadata"]["conference_url"].replace('-', ''))[0][:-1]
 				print("PD CONF : ", conf)
 				if (meeting_id == conf):
 					print(f'I should put this note on incident {bridge["id"]} because conference url is {bridge["metadata"]["conference_url"]}')


### PR DESCRIPTION
There is sometimes a number in the URL host and your regex finds that instead. e.g. https://us04web.zoom.us/j/00000000000?pwd=jcjcjcjcjyN0x0ZDhkcm5TaFI1QT09 will parse 04 when using [\d]+